### PR TITLE
Escape table names in dbMaster.php

### DIFF
--- a/protected/helpers/dbMaster.php
+++ b/protected/helpers/dbMaster.php
@@ -99,8 +99,8 @@ class dbMaster {
 
     /**
      * Dump all tables
-     * @param boolean $download - if the generated data is to be sent to browser 
-     * @return file|strings 
+     * @param boolean $download - if the generated data is to be sent to browser
+     * @return file|strings
      */
     public function getDump($download = TRUE, $prefix = '') {
         ob_start();
@@ -140,7 +140,7 @@ class dbMaster {
 
     /**
      * Generate constraints to all tables
-     * @return string 
+     * @return string
      */
     private function getConstraints() {
         $sql = "--\r\n-- Constraints for dumped tables\r\n--" . PHP_EOL . PHP_EOL;
@@ -169,7 +169,7 @@ class dbMaster {
 
     /**
      * Set sql file header
-     * @return string 
+     * @return string
      */
     private function setHeader() {
         $header = PHP_EOL . "--\n-- foreign key checks, autocomit and start a transaction\n--" . PHP_EOL . PHP_EOL;
@@ -187,7 +187,7 @@ class dbMaster {
 
     /**
      * Set sql file footer
-     * @return string 
+     * @return string
      */
     private function setFooter() {
         $footer = PHP_EOL . "SET FOREIGN_KEY_CHECKS=1" . $this->commandEnd . PHP_EOL;
@@ -280,7 +280,7 @@ class dbMaster {
     }
 
     private static function newGetColumns($tableName, $prefix) {
-        $sql = 'SELECT * FROM ' . $tableName . " LIMIT 1";
+        $sql = 'SELECT * FROM `' . $tableName . "` LIMIT 1";
         $cmd = Yii::$app->db->createCommand($sql);
 
         foreach ($cmd->query() as $data) {
@@ -291,7 +291,7 @@ class dbMaster {
     }
 
     public function newGetData($tableName, $prefix) {
-        $sql = 'SELECT * FROM ' . $tableName ;
+        $sql = 'SELECT * FROM `' . $tableName . '`' ;
         $cmd = Yii::$app->db->createCommand($sql);
         //$dataReader = ;
         $array = [];
@@ -315,9 +315,9 @@ class dbMaster {
         $transaction = $connection->beginTransaction();
         try {
             $connection->createCommand('SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO"')->execute();
-            
+
             foreach ($backup["columns"]as $table => $key) {
-                
+
                 if(Yii::$app->db->schema->getTableSchema($prefix . $table)!==null){
                     $connection->createCommand()->truncateTable($prefix . $table)->execute();
                     Yii::info("restord: " . $prefix . $table);

--- a/test.php
+++ b/test.php
@@ -1,3 +1,0 @@
-<?php
-phpinfo();
-?>

--- a/test.php
+++ b/test.php
@@ -1,0 +1,3 @@
+<?php
+phpinfo();
+?>


### PR DESCRIPTION
Hi,
Thank you for open sourcing this project! I am recommending everyone to use your services (our accountant and clients). While testing it, I encountered a problem, errors with sql table with the special name of 'databases' during the backup action. The table names should be escaped with back tick in two queries in dbMaster to avoid that.

For example instead of 
```php
$sql = 'SELECT * FROM ' . $tableName 
```
write
```php
$sql = 'SELECT * FROM `' . $tableName . '`'
```

oved