### PR TITLE
Fixing web error.

### DIFF
--- a/protected/helpers/Linet3Helper.php
+++ b/protected/helpers/Linet3Helper.php
@@ -91,7 +91,7 @@ class Linet3Helper {
 
     public static function setTheme() {
         $theme = \Yii::$app->user->getParam('theme');
-        if ($theme !== '') {
+        if ($theme && $theme !== '') {
             Yii::$app->view->theme->pathMap = [
                 '@app/views' => '@webroot/themes/' . $theme,
                 '@app/widgets' => '@webroot/themes/' . $theme . '/widgets',


### PR DESCRIPTION
 PHP Warning – yii\base\ErrorException
Creating default object from empty value

    1. in /var/www/html/protected/helpers/Linet3Helper.php at line 95
    8687888990919293949596979899100101102103104

                else
                    return true;
     
            return $setting->value;
        }
     
        public static function setTheme() {
            $theme = \Yii::$app->user->getParam('theme');
            if ($theme !== '') {
                Yii::$app->view->theme->pathMap = [
                    '@app/views' => '@webroot/themes/' . $theme,
                    '@app/widgets' => '@webroot/themes/' . $theme . '/widgets',
                    '@app/modules' => '@webroot/themes/' . $theme . '/modules',
                ];
            }
        }
     
        public static function setSetting($id, $value) {
            if (\Yii::$app->db->schema->getTableSchema('{{%config}}') === null) {
...
...