### PR TITLE
Impossible to create VAT or Tax report from September to October due to validation error.

### DIFF
--- a/protected/models/FormReportTaxrep.php
+++ b/protected/models/FormReportTaxrep.php
@@ -71,8 +71,8 @@ class FormReportTaxrep extends Model {
         // will receive user inputs.
         return array(
             array(['from_month', 'to_month', 'year'], 'required'),
-            array('from_month', 'compare', 'compareAttribute' => 'to_month', 'operator' => '<='),
-            array('to_month', 'compare', 'compareAttribute' => 'from_month', 'operator' => '>='),
+            array('from_month', 'compare', 'compareAttribute' => 'to_month', 'operator' => '<=', 'type' => 'number'),
+            array('to_month', 'compare', 'compareAttribute' => 'from_month', 'operator' => '>=', 'type' => 'number'),
             array(['tax_rate', 'income_sum', 'custtax_sum', 'custtax_total', 'tax_total', 'tax_sum', 'step', 'to_month', 'to_date', 'from_month', 'from_date', 'year',], 'safe'),
             array(['tax_rate', 'income_sum', 'custtax_sum', 'custtax_total', 'tax_total', 'tax_sum', 'step', 'to_month', 'to_date', 'from_month', 'from_date', 'year',], 'safe', 'on' => 'search'),
         );

--- a/protected/models/FormReportVat.php
+++ b/protected/models/FormReportVat.php
@@ -62,8 +62,8 @@ class FormReportVat extends Model {
         // will receive user inputs.
         return array(
             array(['from_month', 'to_month', 'year'], 'required'),
-            array(['from_month'], 'compare', 'compareAttribute' => 'to_month', 'operator' => '<='),
-            array(['to_month'], 'compare', 'compareAttribute' => 'from_month', 'operator' => '>='),
+            array(['from_month'], 'compare', 'compareAttribute' => 'to_month', 'operator' => '<=', 'type' => 'number'),
+            array(['to_month'], 'compare', 'compareAttribute' => 'from_month', 'operator' => '>=', 'type' => 'number'),
             array(['payvat_total', 'income_sum', 'income_sum_novat', 'buyvat_total', 'buyvat_acc', 'assetvat_total', 'assetvat_acc', 'selvat_total', 'selvat_acc', 'step', 'to_month', 'to_date', 'from_month', 'from_date', 'year',], 'safe'),
             array(['payvat_total', 'income_sum', 'income_sum_novat', 'buyvat_total', 'buyvat_acc', 'assetvat_total', 'assetvat_acc', 'selvat_total', 'selvat_acc', 'step', 'to_month', 'to_date', 'from_month', 'from_date', 'year',], 'safe', 'on' => 'search'),
         );


### PR DESCRIPTION
It is not possible to generate VAT report or or Mikdamot report for 
the report range of two months: from 9 to 10.

You will get a validation error if you try to do that. See the screenshot.

![september-october-not-valid](https://user-images.githubusercontent.com/5039379/31277729-fe65c8ee-aaaa-11e7-924c-3d3c1cf1f990.png)

The cause of this validation error is that the months are compared as strings instead of as numbers and
"9" as a string is bigger than "10" as string. So the from_month is larger than the to_month which causes
a validation error.

An additional `'type' => 'number'` should be added to the validation rules
of the from_month and the to_month in the model files FormReportTaxrep.php and FormReportTaxrep.php.

There is a specific note about this issue in the first paragraph of compare validator docs:
http://www.yiiframework.com/doc-2.0/yii-validators-comparevalidator.html
**"The default comparison function is based on string values, which means the values are compared byte by byte. When comparing numbers, make sure to set the $type to TYPE_NUMBER to enable numeric comparison."**

Files that need the fix:
protected/models/FormReportVat.php
protected/models/FormReportTaxrep.php

In the above two files, the lines
`
array(['from_month'], 'compare', 'compareAttribute' => 'to_month', 'operator' => '<='),
`
` array(['to_month'], 'compare', 'compareAttribute' => 'from_month', 'operator' => '>='),
`


Should be replaced with:
`
array('from_month', 'compare', 'compareAttribute' => 'to_month', 'operator' => '<=', 'type' => 'number'),
`
`
array('to_month', 'compare', 'compareAttribute' => 'from_month', 'operator' => '>=', 'type' => 'number'),
`

Note that `'type' => 'number'` has been added.

The branch in the pull request contains only these fixes.